### PR TITLE
Add Javadoc script to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: java
-
 jdk:
   - oraclejdk8
+env:
+  global:
+  - secure: Pxqeif258krW/7m2ncPZXjwdL2tENIueaAiwMWuJ8XJD56ZVtiEykU8w4u8+5vlgmdLRDTs7z3L9eE3/mnzeKH5NUOpAL/1rWx4DhvEonDPOrJfuhDej1rTFYmA+tBjWWYHwYvV59aN19G70Lxv2Z8n56IwkgBThP1h/XNEl4heLnZyO1O7jGOgHqr/+Ldds5tfsxQrygYAHMxdkdEnM6oXaQ1P9FEJ8WBiURUmF3nEMnXOtRzpYHL3hHVXev31bQ7VvpGrKqCGlyJaHvk+u3PWuhsjO6+8SbnF/UWuiwwnQsPn/nj0GI0WZ38rrrl6LCnNmYd4PyxJBZo/A9NLFqvMeTfkoZlkwZwejGLaEr19eF48veyg2Cy1UMn8wcM3xs9xfeMq2fs3w3eXbBOrdg0JSY3WhFbPPfn3gPwM2hKBALJ3j5GN6bWzmt0glXis6XO7zH7C64Z7obONqjl7rY+2U9eJ9EUtqhXxjhb+6oHn6ga9JfGhg8NEiLn6tfrn4qFuNq67ADctteooUP/vtsRIB3yeihs0FSKcI4mWuOBD/Os2Ug5PenAMeNQUANOCgM2JjPD5y2tL/dVBXAYqwy6tNzntSdkhRamlxSKqXj7+2v/XS64vFSZq8hn8hLKLbgjgSvTBsP3ofIzfZ5pB6QZ0/rdMaFX4Ru+aTWwwLvCE=
+before_install:
+  - chmod +x ./script/push-javadoc-to-gh-pages.sh  
+after_success:
+  - gradle javadoc
+  - ./script/push-javadoc-to-gh-pages.sh 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,11 @@ apply plugin: 'java'
 
 sourceCompatibility = 1.8
 
+javadoc {
+    source = sourceSets.main.allJava
+    classpath = configurations.compile
+}
+
 repositories {
     mavenCentral()
 }

--- a/script/push-javadoc-to-gh-pages.sh
+++ b/script/push-javadoc-to-gh-pages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ "$TRAVIS_REPO_SLUG" == "eserial/eserial" ] && [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+
+  echo -e "Publishing Javadoc...\n"
+
+  cp -R build/docs/javadoc $HOME/javadoc-latest
+
+  cd $HOME
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "travis-ci"
+  git clone --quiet --branch=master https://${GH_TOKEN}@github.com/eserial/eserial.github.io master > /dev/null
+
+  cd master
+  git rm -rf .
+  cp -Rf $HOME/javadoc-latest/. .
+  git add -f .
+  git commit -m "Generate Javadoc after successful travis build $TRAVIS_BUILD_NUMBER" 
+  git push -fq origin master > /dev/null
+
+  echo -e "Published Javadoc to eserial.github.io.\n"
+  
+fi


### PR DESCRIPTION
Everytime `master` is changed and the Travis build succeeds, the latest Javadoc is generated and pushed to `eserial/eserial.github.io`. It is accessible by visiting [eserial.github.io](https://eserial.github.io),

Do we want to have this done for all branches or pull requests? In that case the URL would be `eserial.github.io/<branch_name>` _(and I would have to do some more bash magic...)_.